### PR TITLE
added WidthLongestLine

### DIFF
--- a/src/main/java/de/vandermeer/asciitable/v2/render/WidthLongestLine.java
+++ b/src/main/java/de/vandermeer/asciitable/v2/render/WidthLongestLine.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.vandermeer.asciitable.v2.render;
+
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+import de.vandermeer.asciitable.v2.V2_AsciiTable;
+import de.vandermeer.asciitable.v2.row.ContentRow;
+import de.vandermeer.asciitable.v2.row.V2_Row;
+
+/**
+ * Utility to define the width of table columns automatically based on the longest line in each column.
+ *
+ * @author Sebastian Thomschke &lt;sebthom@sourceforge.net&gt;
+ * @version v0.2.2
+ */
+public class WidthLongestLine implements V2_Width {
+    private static final Pattern NEW_LINE = Pattern.compile("[\\r?\\n]+");
+    private static final String[] EMPTY_CELL = new String[] { "" };
+
+    private int[] minWidths = new int[0];
+    private int[] maxWidths = new int[0];
+
+    /**
+     * Adds a column with the the given minimum/maximum column width
+     *
+     * @param minWidth minimum column width in number of characters
+     * @param maxWidth maximum column width in number of characters
+     * @return self to allow for chaining
+     */
+    public WidthLongestLine add(final int minWidth, final int maxWidth) {
+        minWidths = ArrayUtils.add(minWidths, minWidth);
+        maxWidths = ArrayUtils.add(maxWidths, maxWidth);
+        return this;
+    }
+
+    @Override
+    public int[] getColumnWidths(final V2_AsciiTable table) {
+        final int cols = table.getColumnCount();
+        final int[] resultWidths = new int[cols];
+
+        // apply min width settings
+        System.arraycopy(minWidths, 0, resultWidths, 0, minWidths.length > cols ? cols : minWidths.length);
+
+        // iterate over all rows
+        for (final V2_Row row : table.getTable()) {
+            if (row instanceof ContentRow) {
+
+                final ContentRow crow = (ContentRow) row;
+                final Object[] cells = crow.getColumns();
+
+                // iterate over all cells in the row
+                for (int i = 0; i < cells.length; i++) {
+                    final String[] lines = cells[i] == null ? EMPTY_CELL : NEW_LINE.split(cells[i].toString());
+                    // measuring the width of each line within a cell
+                    for (final String line : lines) {
+                        final int lineWidth = line.length() + 2 * crow.getPadding()[i];
+                        if (lineWidth > resultWidths[i]) {
+                            final int maxWidth = maxWidths.length > i ? maxWidths[i] : 0;
+                            if (maxWidth < 1 || lineWidth < maxWidth) {
+                                resultWidths[i] = lineWidth;
+                            } else {
+                                resultWidths[i] = maxWidth;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return resultWidths;
+    }
+}

--- a/src/test/java/de/vandermeer/asciitable/v2/render/Test_WidthLongestLine.java
+++ b/src/test/java/de/vandermeer/asciitable/v2/render/Test_WidthLongestLine.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.vandermeer.asciitable.v2.render;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import de.vandermeer.asciitable.v2.V2_AsciiTable;
+import de.vandermeer.asciitable.v2.themes.V2_E_TableThemes;
+
+/**
+ * Tests for {@link WidthLongestLine}.
+ *
+ * @author Sebastian Thomschke &lt;sebthom@sourceforge.net&gt;
+ * @version v0.2.2
+ */
+public class Test_WidthLongestLine {
+
+    @Test
+    public void test_WidthLongestLine() {
+        final V2_AsciiTableRenderer rend = new V2_AsciiTableRenderer();
+        rend.setTheme(V2_E_TableThemes.PLAIN_7BIT.get());
+
+        V2_AsciiTable at;
+        int[] cols;
+        WidthLongestLine w;
+
+        at = new V2_AsciiTable();
+        final int padd = 2 * at.getDefaultPadding();
+        at.addRule();
+        at.addRow("", "1", "22", "333", "4444");
+        at.addRule();
+        w = new WidthLongestLine();
+        cols = w.getColumnWidths(at);
+
+        System.out.println(at.getDefaultPadding());
+        System.out.println(rend.setWidth(w).render(at));
+        assertEquals(5, cols.length);
+        assertTrue(Arrays.equals(new int[] { padd + 0, padd + 1, padd + 2, padd + 3, padd + 4 }, cols));
+
+        w.add(padd + 2, 0);
+        cols = w.getColumnWidths(at);
+        System.out.println(Arrays.toString(cols));
+        System.out.println(rend.setWidth(w).render(at));
+        assertEquals(5, cols.length);
+        assertTrue(Arrays.equals(new int[] { padd + 2, padd + 1, padd + 2, padd + 3, padd + 4 }, cols));
+
+        w.add(padd + 2, 0);
+        w.add(0, 0);
+        w.add(0, 0);
+        w.add(0, padd + 2);
+        cols = w.getColumnWidths(at);
+        System.out.println(Arrays.toString(cols));
+        System.out.println(rend.setWidth(w).render(at));
+        assertEquals(5, cols.length);
+        assertTrue(Arrays.equals(new int[] { padd + 2, padd + 2, padd + 2, padd + 3, padd + 2 }, cols));
+
+        at.addRow("", "1", "22", "333\n4444", "4444");
+        cols = w.getColumnWidths(at);
+        System.out.println(Arrays.toString(cols));
+        System.out.println(rend.setWidth(w).render(at));
+        assertEquals(5, cols.length);
+        assertTrue(Arrays.equals(new int[] { padd + 2, padd + 2, padd + 2, padd + 4, padd + 2 }, cols));
+    }
+}


### PR DESCRIPTION
Hi,
the WidthLongestLine class calculates the width of each column based on the cell with the longest line. It also supports additional definition of min/max column widths.

It already takes in account cells containing line breaks, which works best when https://github.com/vdmeer/asciitable/issues/2 is fixed.

Regards,
Seb
