### PR TITLE
[#8] added configurable line separator option to AT_Context

### DIFF
--- a/src/main/java/de/vandermeer/asciitable/AT_Context.java
+++ b/src/main/java/de/vandermeer/asciitable/AT_Context.java
@@ -57,6 +57,9 @@ public class AT_Context implements IsTableContext {
 	/** The width of the table, actual width depends on padding settings, default is `80`. */
 	protected int width = 80;
 
+	/** Line separator to separate table rows, defaults to `\n`. */
+	protected String lineSeparator = "\n";
+
 	/** The grid (actual frame) for the table. */
 	protected TA_Grid grid = U8_Grids.borderLight();
 
@@ -139,6 +142,15 @@ public class AT_Context implements IsTableContext {
 	@Override
 	public int getWidth() {
 		return this.width;
+	}
+
+	/**
+	 * Returns the line separator to separate table rows,
+	 * defaults to `\n`.
+	 * @return line separator
+	 */
+	public String getLineSeparator() {
+		return lineSeparator;
 	}
 
 	/**
@@ -325,6 +337,18 @@ public class AT_Context implements IsTableContext {
 	 */
 	public AT_Context setWidth(int width) {
 		this.width = width;
+		return this;
+	}
+
+	/**
+	 * Sets the line separator for table rows.
+	 * @param lineSeparator new line separator
+	 * @return this to allow chaining
+	 */
+	public AT_Context setLineSeparator(String lineSeparator) {
+		if (lineSeparator!=null) {
+			this.lineSeparator = lineSeparator;
+		}
 		return this;
 	}
 

--- a/src/main/java/de/vandermeer/asciitable/AT_Renderer.java
+++ b/src/main/java/de/vandermeer/asciitable/AT_Renderer.java
@@ -142,7 +142,7 @@ public interface AT_Renderer extends IsTableRenderer {
 						}
 						if(content instanceof DoesRenderToWidth){
 							cAr[i] = new StrTokenizer(((DoesRenderToWidth)content).render(length))
-									.setDelimiterChar('\n')
+									.setDelimiterString(ctx.getLineSeparator())
 									.setIgnoreEmptyTokens(false)
 									.getTokenArray()
 							;

--- a/src/main/java/de/vandermeer/asciitable/AsciiTable.java
+++ b/src/main/java/de/vandermeer/asciitable/AsciiTable.java
@@ -182,12 +182,12 @@ public class AsciiTable implements IsTable {
 
 	@Override
 	public String render(){
-		return new StrBuilder().appendWithSeparators(this.renderer.render(this.getRawContent(), this.getColNumber(), this.ctx), "\n").toString();
+		return new StrBuilder().appendWithSeparators(this.renderer.render(this.getRawContent(), this.getColNumber(), this.ctx), this.ctx.getLineSeparator()).toString();
 	}
 
 	@Override
 	public String render(int width){
-		return new StrBuilder().appendWithSeparators(this.renderer.render(this.getRawContent(), this.getColNumber(), this.ctx, this.ctx.getTextWidth(width)), "\n").toString();
+		return new StrBuilder().appendWithSeparators(this.renderer.render(this.getRawContent(), this.getColNumber(), this.ctx, this.ctx.getTextWidth(width)), this.ctx.getLineSeparator()).toString();
 	}
 
 	@Override

--- a/src/site/asciidoc/concepts/04-context.adoc
+++ b/src/site/asciidoc/concepts/04-context.adoc
@@ -7,6 +7,7 @@ The current implementation directly has
 * paragraph alignment (default being justified, last line left)
 * paragraph format (default being none)
 * paragraph width (default being 80)
+* line separator (default being `\n`)
 * an optional library for dropped capital letters (default being not set)
 * an optional theme for a frame (default being not set)
 


### PR DESCRIPTION
- Solves #8 by adding a configurable line separator String to `AT_Context`.
- The new field `AT_Context.lineSeparator` replaces the hardcoded one in `AsciiTable` and `AT_Rendeder`.
- Naturally this needs to be a `String` instead of char, because MsWin would use `\r\n`.
- The default separator is `\n` to stay compatible with previous versions. 