### PR TITLE
Null tolerant rendering of rows (#14)

### DIFF
--- a/src/main/java/de/vandermeer/asciitable/AT_Context.java
+++ b/src/main/java/de/vandermeer/asciitable/AT_Context.java
@@ -71,6 +71,9 @@ public class AT_Context implements IsTableContext {
 	/** Options for the grid, for instance show empty lines. */
 	protected int gridThemeOptions = TA_GridThemeOptions.SHOW_EMPTY_ALL.get();
 
+  /** Value which will be used to render null values in rows */
+	protected String nullValuePlaceholder = "";
+
 	/**
 	 * Returns the bottom frame margin character.
 	 * @return bottom frame margin character
@@ -436,5 +439,16 @@ public class AT_Context implements IsTableContext {
 	 */
 	public String getLineSeparator(){
 		return this.lineSeparator;
+	}
+
+	public String getNullValuePlaceholder(){
+		return nullValuePlaceholder;
+	}
+
+	public AT_Context setNullValuePlaceholder(final String nullValuePlaceholder){
+		if(nullValuePlaceholder != null){
+			this.nullValuePlaceholder = nullValuePlaceholder;
+		}
+		return this;
 	}
 }

--- a/src/main/java/de/vandermeer/asciitable/AT_Renderer.java
+++ b/src/main/java/de/vandermeer/asciitable/AT_Renderer.java
@@ -204,8 +204,7 @@ public interface AT_Renderer extends IsTableRenderer {
 
 						Object content = cells.get(i).getContent();
 						if(content==null){
-							length++;
-							continue;
+							content = ctx.getNullValuePlaceholder();
 						}
 
 						int realWidth = length;

--- a/src/test/java/de/vandermeer/asciitable/TestNullValueInRow.java
+++ b/src/test/java/de/vandermeer/asciitable/TestNullValueInRow.java
@@ -1,0 +1,43 @@
+package de.vandermeer.asciitable;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestNullValueInRow {
+
+  @Test
+  public void testNullRowDefaultPlaceholder() {
+    AsciiTable at = createDemoTable(new AT_Context());
+    final String expected =
+        "┌───────────────────────────────────────┬──────────────────────────────────────┐\n" +
+        "│row 1 col 1                            │row 1 col 2                           │\n" +
+        "├───────────────────────────────────────┼──────────────────────────────────────┤\n" +
+        "│row 2 col 1                            │                                      │\n" +
+        "└───────────────────────────────────────┴──────────────────────────────────────┘";
+
+    Assert.assertEquals(expected, at.render());
+  }
+
+  @Test
+  public void testNullRowCustomPlaceholder() {
+    AsciiTable at = createDemoTable(new AT_Context().setNullValuePlaceholder("NULL"));
+    final String expected =
+        "┌───────────────────────────────────────┬──────────────────────────────────────┐\n" +
+        "│row 1 col 1                            │row 1 col 2                           │\n" +
+        "├───────────────────────────────────────┼──────────────────────────────────────┤\n" +
+        "│row 2 col 1                            │NULL                                  │\n" +
+        "└───────────────────────────────────────┴──────────────────────────────────────┘";
+
+    Assert.assertEquals(expected, at.render());
+  }
+
+  private AsciiTable createDemoTable(final AT_Context context) {
+    AsciiTable at = new AsciiTable(context);
+    at.addRule();
+    at.addRow("row 1 col 1", "row 1 col 2");
+    at.addRule();
+    at.addRow("row 2 col 1", null);
+    at.addRule();
+    return at;
+  }
+}


### PR DESCRIPTION
Fixes #14, where rendering crashes if a row contains any `null` value. The placeholder for `null` values can be configured using the `nullValuePlaceholder` property of a table context, by default set to empty String. 